### PR TITLE
Config tag creation

### DIFF
--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -38,8 +38,10 @@ jobs:
           echo "Creates release xxx with content vvv"
           ls -lah ${{ github.workspace }}
           git -v
+          git remote -v
           git tag $VERSION
           git push --tags
+          git tag -l
 
 
   deploy:


### PR DESCRIPTION
when tag created in action, ti should be published in the master branch, why it fails?